### PR TITLE
Restrict ordinary user to entering and viewing details only

### DIFF
--- a/app/src/main/java/ie/lyit/app/web/rest/CategoryResource.java
+++ b/app/src/main/java/ie/lyit/app/web/rest/CategoryResource.java
@@ -2,6 +2,7 @@ package ie.lyit.app.web.rest;
 
 import ie.lyit.app.domain.Category;
 import ie.lyit.app.repository.CategoryRepository;
+import ie.lyit.app.security.AuthoritiesConstants;
 import ie.lyit.app.service.CategoryService;
 import ie.lyit.app.web.rest.errors.BadRequestAlertException;
 import java.net.URI;
@@ -15,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import tech.jhipster.web.util.HeaderUtil;
 import tech.jhipster.web.util.ResponseUtil;
@@ -73,6 +75,7 @@ public class CategoryResource {
      * @throws URISyntaxException if the Location URI syntax is incorrect.
      */
     @PutMapping("/categories/{id}")
+    @PreAuthorize("hasAuthority(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<Category> updateCategory(
         @PathVariable(value = "id", required = false) final Long id,
         @Valid @RequestBody Category category
@@ -163,6 +166,7 @@ public class CategoryResource {
      * @return the {@link ResponseEntity} with status {@code 204 (NO_CONTENT)}.
      */
     @DeleteMapping("/categories/{id}")
+    @PreAuthorize("hasAuthority(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
         log.debug("REST request to delete Category : {}", id);
         categoryService.delete(id);

--- a/app/src/main/java/ie/lyit/app/web/rest/EmployeeResource.java
+++ b/app/src/main/java/ie/lyit/app/web/rest/EmployeeResource.java
@@ -2,6 +2,7 @@ package ie.lyit.app.web.rest;
 
 import ie.lyit.app.domain.Employee;
 import ie.lyit.app.repository.EmployeeRepository;
+import ie.lyit.app.security.AuthoritiesConstants;
 import ie.lyit.app.web.rest.errors.BadRequestAlertException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -77,6 +79,7 @@ public class EmployeeResource {
      * @throws URISyntaxException if the Location URI syntax is incorrect.
      */
     @PutMapping("/employees/{id}")
+    @PreAuthorize("hasAuthority(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<Employee> updateEmployee(
         @PathVariable(value = "id", required = false) final Long id,
         @Valid @RequestBody Employee employee
@@ -190,6 +193,7 @@ public class EmployeeResource {
      * @return the {@link ResponseEntity} with status {@code 204 (NO_CONTENT)}.
      */
     @DeleteMapping("/employees/{id}")
+    @PreAuthorize("hasAuthority(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<Void> deleteEmployee(@PathVariable Long id) {
         log.debug("REST request to delete Employee : {}", id);
         employeeRepository.deleteById(id);

--- a/app/src/main/java/ie/lyit/app/web/rest/FileResource.java
+++ b/app/src/main/java/ie/lyit/app/web/rest/FileResource.java
@@ -2,6 +2,7 @@ package ie.lyit.app.web.rest;
 
 import ie.lyit.app.domain.File;
 import ie.lyit.app.repository.FileRepository;
+import ie.lyit.app.security.AuthoritiesConstants;
 import ie.lyit.app.service.FileService;
 import ie.lyit.app.web.rest.errors.BadRequestAlertException;
 import java.net.URI;
@@ -17,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import tech.jhipster.web.util.HeaderUtil;
@@ -77,6 +79,7 @@ public class FileResource {
      * @throws URISyntaxException if the Location URI syntax is incorrect.
      */
     @PutMapping("/files/{id}")
+    @PreAuthorize("hasAuthority(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<File> updateFile(@PathVariable(value = "id", required = false) final Long id, @RequestBody File file)
         throws URISyntaxException {
         log.debug("REST request to update File : {}, {}", id, file);
@@ -166,6 +169,7 @@ public class FileResource {
      * @return the {@link ResponseEntity} with status {@code 204 (NO_CONTENT)}.
      */
     @DeleteMapping("/files/{id}")
+    @PreAuthorize("hasAuthority(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<Void> deleteFile(@PathVariable Long id) {
         log.debug("REST request to delete File : {}", id);
         fileService.delete(id);

--- a/app/src/main/java/ie/lyit/app/web/rest/SkillResource.java
+++ b/app/src/main/java/ie/lyit/app/web/rest/SkillResource.java
@@ -2,6 +2,7 @@ package ie.lyit.app.web.rest;
 
 import ie.lyit.app.domain.Skill;
 import ie.lyit.app.repository.SkillRepository;
+import ie.lyit.app.security.AuthoritiesConstants;
 import ie.lyit.app.web.rest.errors.BadRequestAlertException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -75,6 +77,7 @@ public class SkillResource {
      * @throws URISyntaxException if the Location URI syntax is incorrect.
      */
     @PutMapping("/skills/{id}")
+    @PreAuthorize("hasAuthority(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<Skill> updateSkill(@PathVariable(value = "id", required = false) final Long id, @RequestBody Skill skill)
         throws URISyntaxException {
         log.debug("REST request to update Skill : {}, {}", id, skill);
@@ -187,6 +190,7 @@ public class SkillResource {
      * @return the {@link ResponseEntity} with status {@code 204 (NO_CONTENT)}.
      */
     @DeleteMapping("/skills/{id}")
+    @PreAuthorize("hasAuthority(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<Void> deleteSkill(@PathVariable Long id) {
         log.debug("REST request to delete Skill : {}", id);
         skillRepository.deleteById(id);

--- a/app/src/main/webapp/app/entities/category/detail/category-detail.component.html
+++ b/app/src/main/webapp/app/entities/category/detail/category-detail.component.html
@@ -24,7 +24,7 @@
         <fa-icon icon="arrow-left"></fa-icon>&nbsp;<span>Back</span>
       </button>
 
-      <button type="button" [routerLink]="['/category', category.id, 'edit']" class="btn btn-primary">
+      <button *jhiHasAnyAuthority="'ROLE_ADMIN'" type="button" [routerLink]="['/category', category.id, 'edit']" class="btn btn-primary">
         <fa-icon icon="pencil-alt"></fa-icon>&nbsp;<span>Edit</span>
       </button>
     </div>

--- a/app/src/main/webapp/app/entities/category/list/category.component.html
+++ b/app/src/main/webapp/app/entities/category/list/category.component.html
@@ -55,7 +55,7 @@
                 <span class="d-none d-md-inline">View</span>
               </button>
 
-              <button
+              <button *jhiHasAnyAuthority="'ROLE_ADMIN'"
                 type="submit"
                 [routerLink]="['/category', category.id, 'edit']"
                 class="btn btn-primary btn-sm"
@@ -65,7 +65,7 @@
                 <span class="d-none d-md-inline">Edit</span>
               </button>
 
-              <button type="submit" (click)="delete(category)" class="btn btn-danger btn-sm" data-cy="entityDeleteButton">
+              <button *jhiHasAnyAuthority="'ROLE_ADMIN'" type="submit" (click)="delete(category)" class="btn btn-danger btn-sm" data-cy="entityDeleteButton">
                 <fa-icon icon="times"></fa-icon>
                 <span class="d-none d-md-inline">Delete</span>
               </button>

--- a/app/src/main/webapp/app/entities/employee/detail/employee-detail.component.html
+++ b/app/src/main/webapp/app/entities/employee/detail/employee-detail.component.html
@@ -36,7 +36,7 @@
         <fa-icon icon="arrow-left"></fa-icon>&nbsp;<span>Back</span>
       </button>
 
-      <button type="button" [routerLink]="['/employee', employee.id, 'edit']" class="btn btn-primary">
+      <button *jhiHasAnyAuthority="'ROLE_ADMIN'" type="button" [routerLink]="['/employee', employee.id, 'edit']" class="btn btn-primary">
         <fa-icon icon="pencil-alt"></fa-icon>&nbsp;<span>Edit</span>
       </button>
     </div>

--- a/app/src/main/webapp/app/entities/employee/list/employee.component.html
+++ b/app/src/main/webapp/app/entities/employee/list/employee.component.html
@@ -61,7 +61,7 @@
                 <span class="d-none d-md-inline">View</span>
               </button>
 
-              <button
+              <button *jhiHasAnyAuthority="'ROLE_ADMIN'"
                 type="submit"
                 [routerLink]="['/employee', employee.id, 'edit']"
                 class="btn btn-primary btn-sm"
@@ -71,7 +71,7 @@
                 <span class="d-none d-md-inline">Edit</span>
               </button>
 
-              <button type="submit" (click)="delete(employee)" class="btn btn-danger btn-sm" data-cy="entityDeleteButton">
+              <button *jhiHasAnyAuthority="'ROLE_ADMIN'" type="submit" (click)="delete(employee)" class="btn btn-danger btn-sm" data-cy="entityDeleteButton">
                 <fa-icon icon="times"></fa-icon>
                 <span class="d-none d-md-inline">Delete</span>
               </button>

--- a/app/src/main/webapp/app/entities/file/detail/file-detail.component.html
+++ b/app/src/main/webapp/app/entities/file/detail/file-detail.component.html
@@ -30,7 +30,7 @@
         <fa-icon icon="arrow-left"></fa-icon>&nbsp;<span>Back</span>
       </button>
 
-      <button type="button" [routerLink]="['/file', file.id, 'edit']" class="btn btn-primary">
+      <button *jhiHasAnyAuthority="'ROLE_ADMIN'" type="button" [routerLink]="['/file', file.id, 'edit']" class="btn btn-primary">
         <fa-icon icon="pencil-alt"></fa-icon>&nbsp;<span>Edit</span>
       </button>
     </div>

--- a/app/src/main/webapp/app/entities/file/list/file.component.html
+++ b/app/src/main/webapp/app/entities/file/list/file.component.html
@@ -56,12 +56,12 @@
                 <span class="d-none d-md-inline">View</span>
               </button>
 
-              <button type="submit" [routerLink]="['/file', file.id, 'edit']" class="btn btn-primary btn-sm" data-cy="entityEditButton">
+              <button *jhiHasAnyAuthority="'ROLE_ADMIN'" type="submit" [routerLink]="['/file', file.id, 'edit']" class="btn btn-primary btn-sm" data-cy="entityEditButton">
                 <fa-icon icon="pencil-alt"></fa-icon>
                 <span class="d-none d-md-inline">Edit</span>
               </button>
 
-              <button type="submit" (click)="delete(file)" class="btn btn-danger btn-sm" data-cy="entityDeleteButton">
+              <button *jhiHasAnyAuthority="'ROLE_ADMIN'" type="submit" (click)="delete(file)" class="btn btn-danger btn-sm" data-cy="entityDeleteButton">
                 <fa-icon icon="times"></fa-icon>
                 <span class="d-none d-md-inline">Delete</span>
               </button>

--- a/app/src/main/webapp/app/entities/skill/detail/skill-detail.component.html
+++ b/app/src/main/webapp/app/entities/skill/detail/skill-detail.component.html
@@ -42,7 +42,7 @@
         <fa-icon icon="arrow-left"></fa-icon>&nbsp;<span>Back</span>
       </button>
 
-      <button type="button" [routerLink]="['/skill', skill.id, 'edit']" class="btn btn-primary">
+      <button *jhiHasAnyAuthority="'ROLE_ADMIN'" type="button" [routerLink]="['/skill', skill.id, 'edit']" class="btn btn-primary">
         <fa-icon icon="pencil-alt"></fa-icon>&nbsp;<span>Edit</span>
       </button>
     </div>

--- a/app/src/main/webapp/app/entities/skill/list/skill.component.html
+++ b/app/src/main/webapp/app/entities/skill/list/skill.component.html
@@ -52,12 +52,12 @@
                 <span class="d-none d-md-inline">View</span>
               </button>
 
-              <button type="submit" [routerLink]="['/skill', skill.id, 'edit']" class="btn btn-primary btn-sm" data-cy="entityEditButton">
+              <button *jhiHasAnyAuthority="'ROLE_ADMIN'" type="submit" [routerLink]="['/skill', skill.id, 'edit']" class="btn btn-primary btn-sm" data-cy="entityEditButton">
                 <fa-icon icon="pencil-alt"></fa-icon>
                 <span class="d-none d-md-inline">Edit</span>
               </button>
 
-              <button type="submit" (click)="delete(skill)" class="btn btn-danger btn-sm" data-cy="entityDeleteButton">
+              <button *jhiHasAnyAuthority="'ROLE_ADMIN'" type="submit" (click)="delete(skill)" class="btn btn-danger btn-sm" data-cy="entityDeleteButton">
                 <fa-icon icon="times"></fa-icon>
                 <span class="d-none d-md-inline">Delete</span>
               </button>


### PR DESCRIPTION
I updated the backend Java code so that only Admins can edit or delete records.  The code changes will ensure that ordinary users cannot perform Edits or Deletes via the application or via an API call.  Users can now only add and view records.  I also hid the various Edit and Delete buttons from the frontend HTML so that only Admins can see them.  

