### PR TITLE
Add startup script

### DIFF
--- a/app/scripts/StartApplication.bat
+++ b/app/scripts/StartApplication.bat
@@ -1,0 +1,2 @@
+docker-compose -f ../src/main/docker/local-dev.yml up -d
+mvn -f ../pom.xml spring-boot:run -Pdev

--- a/app/scripts/StartApplication.sh
+++ b/app/scripts/StartApplication.sh
@@ -1,0 +1,2 @@
+docker-compose -f ../src/main/docker/local-dev.yml up -d
+mvn -f ../pom.xml spring-boot:run -Pdev


### PR DESCRIPTION
Added two scripts to make it easier for local development. Running this script will start all the application dependencies(mysql, localstack etc) and the springboot app using dev profile

cd into app/scripts

Mac: run `sh StartApplication.sh`

or 

Windows : `StartApplication.bat`